### PR TITLE
Minor modifications to make it a suitable replacement for my `./build` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ name = "my-packages"
 For each source in this configuration file, the following globs will be expanded to find packages to build:
 
 * `$SOURCE_PATH/*/PKGBUILD` will be built with [makepkg(8)](https://www.archlinux.org/pacman/makepkg.8.html).
+* `$SOURCE_PATH/*.PKGBUILD` will be built with [makepkg(8)](https://www.archlinux.org/pacman/makepkg.8.html) -p.
 * `$SOURCE_PATH/*.pkg.toml` will be built with [holo-build(8)](https://github.com/holocm/holo-build).
 
 Note that directories will not be traversed any deeper than that. For example, any PKGBUILD file must be in a direct

--- a/makepkg.go
+++ b/makepkg.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -39,6 +40,7 @@ func readMakepkgConfig() (MakepkgConfig, error) {
 	}
 
 	var result MakepkgConfig
+	result.GPGKeyID = os.Getenv("GPGKEY")
 	for _, line := range strings.Split(string(bytes), "\n") {
 		line = strings.TrimSpace(line)
 		match := makepkgFieldRegex.FindStringSubmatch(line)

--- a/package.go
+++ b/package.go
@@ -102,7 +102,7 @@ func (pkg NativePackage) CacheKey() string {
 
 //LastModified implements the Package interface.
 func (pkg NativePackage) LastModified() (time.Time, error) {
-	fi, err := os.Stat(filepath.Join(pkg.Path, "PKGBUILD"))
+	fi, err := os.Stat(pkg.Path)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -111,8 +111,8 @@ func (pkg NativePackage) LastModified() (time.Time, error) {
 
 //OutputFiles implements the Package interface.
 func (pkg NativePackage) OutputFiles() ([]string, error) {
-	cmd := exec.Command("makepkg", "--packagelist")
-	cmd.Dir = pkg.Path
+	cmd := exec.Command("makepkg", "--packagelist", "-p", filepath.Base(pkg.Path))
+	cmd.Dir = filepath.Dir(pkg.Path)
 	cmd.Stdin = nil
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
@@ -135,8 +135,8 @@ func (pkg NativePackage) OutputFiles() ([]string, error) {
 
 //Build implements the Package interface.
 func (pkg NativePackage) Build(targetDirPath string) error {
-	cmd := exec.Command("makepkg", "-s")
-	cmd.Dir = pkg.Path
+	cmd := exec.Command("makepkg", "-s", "-p", filepath.Base(pkg.Path))
+	cmd.Dir = filepath.Dir(pkg.Path)
 	cmd.Stdin = nil
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/source.go
+++ b/source.go
@@ -56,10 +56,18 @@ func (s *Source) discoverPackages(mcfg MakepkgConfig) error {
 			}
 			if isRegularOrSymlink(fi2.Mode()) {
 				s.Packages = append(s.Packages, &NativePackage{
-					Path:          pkgPath,
+					Path:          filepath.Join(pkgPath, "PKGBUILD"),
 					MakepkgConfig: mcfg,
 				})
 			}
+		}
+
+		//regular file or symlink: is a package if suffix ".PKGBUILD"
+		if isRegularOrSymlink(fi.Mode()) && strings.HasSuffix(pkgPath, ".PKGBUILD") {
+			s.Packages = append(s.Packages, &NativePackage{
+				Path:          pkgPath,
+				MakepkgConfig: mcfg,
+			})
 		}
 
 		//regular file or symlink: is a holo-build package if suffix ".pkg.toml"


### PR DESCRIPTION
This makes 2 changes so that `art` can be a drop-in replacement for the ugly `./build` shell script that I use for my holograms.

 - build `name.PKGBUILD` using `makepkg -p name.PKGBUILD`
 - get `GPGKEY` from the environment if it isn't in `makepkg.conf` (this is what `makepkg` does)

Maybe this should be two different pull requests, but both things were small enough that it seemed like that would just be more noise.  If you like one of the commits but not the other, you may simply `git cherry-pick` it.