### PR TITLE
Makefile: Add `@latest` to go install url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PKG    = github.com/majewsky/art
+PKG    = github.com/majewsky/art@latest
 PREFIX = /usr
 
 GO            = GOPATH=$(CURDIR)/.gopath GOBIN=$(CURDIR)/build go


### PR DESCRIPTION
Fix error raised by 1.17.1:
```
go install: version is required when current directory is not in a module
        Try 'go install github.com/majewsky/art@latest' to install the latest version
```